### PR TITLE
Declare correct Python version support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Herberton Candido Souza',
     author_email='herberton@gmail.com',
     license='Apache-2.0',
-    python_requires='>=3',
+    python_requires='>=3.9',
     packages=['mkdocs_expose_page_metadata'],
     install_requires=[
         'mkdocs>=1.1.2'


### PR DESCRIPTION
Hi,

I've tried your plugin in Python 3.8 and it seems that uses [Type Hinting Generics in Standard Collections](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections), a feature added in Python 3.9. In versions prior to 3.9, the next error is raised:

```
  File "/.../venv/lib/python3.8/site-packages/mkdocs_expose_page_metadata/helpers.py", line 29, in <module>
    def string_remove_list(text: str, olds: list[str], count: int=-1, strip: bool=False):
TypeError: 'type' object is not subscriptable
```

So I've declared in setup script that the minimum Python version required is 3.9. Keep in mind that after this, if you try to install the plugin in a lower Python version, the next error will be raised at installation time:

```
ERROR: Package 'mkdocs-expose-page-metadata' requires a different Python: 3.8.10 not in '>=3.9'
```

Cheers!